### PR TITLE
Renamed get method to reflect changes in other files

### DIFF
--- a/backend/pipeline/__init__.py
+++ b/backend/pipeline/__init__.py
@@ -48,9 +48,9 @@ class Pipeline:
         pass
 
     @abstractmethod
-    def get(self, batch_element : BatchElement):
+    def post(self, batch_element : BatchElement):
         """
-        Send completed batch element to data destination.
+        Post completed batch element to data destination.
         """
         pass
 
@@ -84,4 +84,4 @@ class Pipeline:
         task = pickle.loads(tasks)
         batch_element = task.data
 
-        self.get(batch_element)
+        self.post(batch_element)

--- a/backend/pipeline/text_captions.py
+++ b/backend/pipeline/text_captions.py
@@ -47,7 +47,7 @@ class TextCaptionPipeline(Pipeline):
 
         return batch_element
 
-    def get(self, batch_element : TextCaptionBatchElement):
+    def post(self, batch_element : TextCaptionBatchElement):
         caption_index = [elem for elem in batch_element.caption_index]
         captions = [elem for elem in batch_element.captions]
 


### PR DESCRIPTION
Changed get to post to better clarify what it's doing. Fetch/get are bad names to use together as they imply the same thing.