### PR TITLE
Gradio update

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,16 +10,10 @@ Then start the server (should do this on a different screen/window)
 ```
 rabbitmq-server
 ```
-Assuming a source dataset is present (you may generate one with the generate_test_dataset.py script), the following command will run a text captioning task on the source dataset, returning a URL for you to access the labelling UI:
+As an example, the following script runs an image selection task, where two images from LAION-art dataset are presented and the labeller is asked to choose one.
 ```
-python -m examples.test_gradio_api
+python -m examples.image_selection
 ```
 
 # Custom tasks in Gradio
-Making new tasks with a gradio frontend in CHEESE is very simple! You will have to define subclasses for:
-backend.data.BatchElement (a dataclass)
-backend.pipeline.Pipeline
-backend.client.gradio_client.GradioClient
-backend.client.gradio_client.GradioClientFront
-
-You may refer to audio_rating.py scripts within the folders for the above objects for an example on how to use CHEESE for the task of rating a folder of WAV files. The script relevant to running the task is examples/audio_test.py
+Refer to examples/image_selection.py for a comprehensive example on how to create your own custom task with a Gradio UI.

--- a/backend/client/gradio_client.py
+++ b/backend/client/gradio_client.py
@@ -1,6 +1,6 @@
 from abc import abstractmethod
 
-from typing import Any, Iterable
+from typing import Any, Iterable, Dict, Tuple, List
 
 from backend.data import BatchElement
 from backend.tasks import Task
@@ -10,176 +10,305 @@ import backend.utils.msg_constants as msg_constants
 from backend.utils.rabbit_utils import rabbitmq_callback
 
 import pickle
+import joblib
 
 from b_rabbit import BRabbit
-import gradio
+import gradio as gr
 from gradio.components import IOComponent
 import time
 
-class GradioClient:
-    def __init__(self, id : int):
-        self.id = id
-        self.task : Task = None
+import random
 
-        self.manager : ClientManager = None
-        self.front : GradioClientFront = None
-    
-    def set_manager(self, manager : ClientManager):
-        self.manager = manager
-
-    def notify(self):
-        """
-        Notify manager this client has finished task.
-        """
-        try:
-            assert self.manager is not None
-        except:
-            raise Exception("Error: Trying to notify ClientManager when it was never set")
-
-        self.manager.notify_completion(self.id)
-    
-    def get_task(self) -> Task:
-        """
-        Return task and unset it. 
-        """
-        res = self.task
-        self.task = None
-        return res
-    
-    def push_task(self, task : Task):
-        """
-        Pass a new task to client for it to work on.
-        """
-        try:
-            assert self.front is not None
-        except:
-            raise Exception("Error: Pushed task to frontend before it was initialized")
-
-        self.task = task
-        data : BatchElement = task.data
-        self.front.update(data)
-
-
-    @abstractmethod
-    def init_front(self, front_cls = None) -> str:
-        """
-        Initialize frontend for this particular client and return a URL to access it.
-        """
-        self.front = front_cls()
-        self.front.set_client(self)
-
-        return self.front.launch()
-
-    def front_ping(self):
-        """
-        For frontend to ping client that it is done with task
-        """
-        self.task.data = self.front.data
-        self.notify()
-
-class GradioClientFront:
+class GradioClientManager(ClientManager):
+    """
+    ClientManager for frontends made in Gradio
+    """
     def __init__(self):
-        self.demo : gradio.Interface = None
-        self.data : BatchElement = None # Data currently being shown to user
-        self.buffer : BatchElement = None # Buffer for next data to show user
-
-        self.showing_data = False # is data visible to user currently?
-        self.client : GradioClient = None
-
-        self.launched = False
-
-    def make_demo(self, inputs : Iterable[IOComponent], outputs : Iterable[IOComponent]):
-        """
-        Given a list of inputs and outputs for gradio, constructs demo. Should always be called by a class instance constructor.
-        """
-        self.demo = gradio.Interface(
-            fn = self.response,
-            inputs = inputs,
-            outputs = outputs
-        )
-
-    def set_client(self, parent : GradioClient):
-        """
-        Set client that is "parent" to this frontend.
-
-        :param parent: Parent of frontend
-        :type parent: Client
-        """
-        self.client = parent
+        # Rabbit connections
+        self.publisher = None # to pipeline or model
+        self.subscriber = None # get tasks (from pipeline)
+        self.subscriber_active = None # get active tasks
     
-    def update(self, data : BatchElement):
-        """
-        Update the buffer with new data
-        """
-        self.buffer = data
+        # Info on users
+        # NOTE: This is just for test purposes and is very barebones,
+        # will need to update to something more secure before using in 
+        # a setting where security is important
+        self.id_pass : Dict[int, int] = {} # [Client ID, Password]
 
-    def complete_task(self):
+        self.client_tasks : Dict[int, Iterable[Task]]= {} # 
+        self.client_states : Dict[int, CS] = {}
+
+        self.front : GradioFront = None
+
+    def init_front(self, front_cls):
+        self.front = front_cls()
+        self.front.set_manager(self)
+        self.front.launch()
+
+    def save_user_info(self, path):
         """
-        Finish task and wipe data. Ping parent client
+        Save info on current users to a file
         """
-        self.showing_data = False
-        self.client.front_ping()
-        self.data = None
+        joblib.dump(self.id_pass, path)
     
-    def refresh(self) -> bool:
+    def load_user_info(self, path):
         """
-        Refresh data from buffer.
+        Load info on users from a previously saved file
+        """
+        self.id_pass = joblib.load(path)
 
-        :return: Whether or not there is new data to present after the refresh
-        :rtype: bool
+
+    def add_client(self, id : int):
         """
-        if self.buffer is not None:
-            self.data = self.buffer
-            self.buffer = None
-        if self.data is not None:
-            self.showing_data = True
-            return True
+        Add a new client. Creates a user/pass combo.
+
+        :param id: ID for the new client
+        """
+        if id in self.id_pass:
+            raise Exception("Error: Trying to create client with ID that has already been taken")
+        
+        self.client_tasks[id] = []
+        self.client_states[id] = CS.IDLE
+
+        pwd = random.randrange(100000,999999)
+
+        self.id_pass[id] = pwd
+
+        return id, pwd
+
+    def remove_client(self, id : int):
+        del self.client_tasks[id]
+        del self.client_states[id]
+        del self.id_pass[id]
+
+    def query_client(self, id : int, password : int):
+        if id in self.id_pass:
+            if self.id_pass[id] == password:
+                return True
         return False
 
-    def launch(self) -> str:
+    def await_new_task(self, id : int) -> Task:
         """
-        Launch the frontend application and return URL to access it
+        GradioFront should call this with ID of client. It will return a new task if one is available. Otherwise,
+        it will loop and wait for one.
+        
+        :param id: ID of the client awaiting a task
 
-        :return: URL for user to access frontend
-        :rtype: str
+        :return: A task, as soon as it is available
         """
-        try:
-            assert self.client is not None
-        except:
-            raise Exception("Error: Launched frontend with unspecified parent client")
 
-        _, _, url = self.demo.launch(
-            share = True, quiet = True,
-            prevent_thread_lock = True,
-            enable_queue = True
-        )
-        self.launched = True
-        return url
+        if not id in self.id_pass:
+            raise Exception("Awaiting task for ID that is not registered as a client")
 
+        while True:
+            if self.client_tasks[id]:
+                return self.client_tasks[id].pop(0)
+            time.sleep(0.5)
+    
+    def submit_task(self, id : int, task : Task):
+        """
+        GradioFront should call this to submit a finished task.
+
+        :param id: ID of the client submitting a task
+        
+        :param task: The finished task
+        """
+
+        self.queue_task(id, task)
+
+    def queue_task(self, id : int, task : Task):
+        """
+        Given a client id, queues the task that was assigned to that client and marks client as free or active accordingly.
+        """
+
+        task.data.client_id = id
+        task.client_id = id
+
+        tasks = pickle.dumps(task)
+
+        to_pipeline = task.data.trip >= task.data.trip_max
+
+        if to_pipeline:
+            self.client_states[id] = CS.IDLE
+
+            # Send finished task to pipeline
+            self.publisher.publish(
+                routing_key = 'pipeline',
+                payload = tasks
+            )
+            
+            # Tell main object we are ready for more data
+            self.publisher.publish(
+                routing_key = 'main',
+                payload = msg_constants.SENT
+            )
+        else: # send to model
+            self.client_states[id] = CS.WAITING
+
+            self.publisher.publish(
+                routing_key = 'model',
+                payload = tasks
+            )
+    
+    @rabbitmq_callback
+    def dequeue_task(self, tasks : str):
+        """
+        Receive message for a new task. Assume this is from pipeline
+        """
+        task : Task = pickle.loads(tasks)
+        task.data.trip += 1
+
+        for id in self.clients:
+            if self.client_states[id] == CS.IDLE:
+                self.client_tasks[id].append(task)
+                self.client_states[id] = CS.BUSY
+
+                self.publisher.publish(
+                    routing_key = 'main',
+                    payload = msg_constants.RECEIVED
+                )
+                return
+        
+        raise Exception("Error: New task dequeued with no free clients to receive.")
+    
+    @rabbitmq_callback
+    def dequeue_active_task(self, tasks : str):
+        """
+        Receive message for in progress (active) task. Assumed to be from model
+        """
+        task : Task = pickle.loads(tasks)
+
+        id = task.client_id
+
+        if id not in self.client_states:
+            raise Exception(f"Error: Active task dequeued but target client with id {id} does not exist")
+        if self.client_states[id] != CS.WAITING:
+            raise Exception("Error: Active task dequeued but target client was not waiting for any active tasks.")
+        
+        task.data.trip += 1
+        self.client_tasks[id].append(task)
+        self.client_states[id] = CS.BUSY
+
+class GradioFront:
+    """
+    Frontend for CHEESE using Gradio
+    """
+    def __init__(self):
+        self.manager : GradioClientManager = None
+        with gr.Blocks() as self.demo:
+            self.id : gr.State = gr.State(-1)
+            self.task : gr.State = gr.State(None)
+
+            with gr.Column(visible = True) as login:
+                login_comps : Dict[str, gr.IOComponent] = self.login()
+
+            with gr.Column(visible = False) as main:
+                self.main()
+            
+            # Deal with login here
+            def login_fn(id, pwd):
+                valid = True
+                try:
+                    id = int(id)
+                    pwd = int(pwd)
+                except:
+                    valid = False
+                
+                if valid:
+                    valid = self.manager.query_client(id, pwd)
+                
+                if valid:
+                    # When valid, get a task then switch to main screen
+                    task = self.manager.await_new_task(id)
+                    return id, task, gr.update(), gr.update(visible = False), gr.update(visible = True)
+                else:
+                    return id, None, gr.update(visible = True), gr.update(), gr.update()
+            
+            login_comps["submit"].click(
+                login_fn,
+                inputs = [login_comps["idbox"], login_comps["pwdbox"]],
+                outputs = [self.id, self.task, login_comps["error"], login, main]
+            )
+    
+    def launch(self):
+        """
+        Launch Gradio demo
+        """
+        if self.manager is None:
+            raise Exception("Error: Tried to lanuch frontend without connecting it to a client manager. Please use GradioFront.set_manager()")
+        
+        self.demo.launch(share = True)
+
+    def set_manager(self, manager : GradioClientManager):
+        """
+        Set the manager for the frontend. This is how it will communicate with backend. Must be set before calling launch
+        """
+        self.manager = manager
+    
+    def login(self):
+        """
+        Returns basic components for login screen
+        """
+        gr.Textbox("Welcome to CHEESE!", show_label = False, interactive = False).style(rounded = False, border = False)
+        idbox = gr.Textbox(label = "User ID", interactive = True)
+        pwdbox = gr.Textbox(label = "User Password", interactive = True)
+        submit = gr.Button("Submit")
+        error = gr.Textbox("Invalid ID or password", visible = False).style(rounded = False, border = False)
+        
+        return {"idbox" : idbox, "pwdbox" : pwdbox, "submit" : submit, "error" : error}
+            
+    @abstractmethod
+    def main(self):
+        """
+        Gradio interface for collecting data can be written here. Should call GradioFront.response() with
+        self. Please read the documentation of GradioFront.response for information on which specific inputs
+        and outputs must go to/come out of the function.
+        """
+        pass
+
+    @abstractmethod
+    def receive(self, *inp) -> Task:
+        """
+        Receive input from user and modify the data in the task with it.
+        Can enforce input validity by raising InvalidInputException.
+        Assumes first two parameters in inp are ID and Task respectively.
+        
+        :return: task modified to reflect user input
+        """
+        pass
+
+    @abstractmethod
+    def present(self, task : Task) -> List[gr.IOComponent]:
+        """
+        Present data in the task to user. Should take task and return outputs to gradio functions
+        in list form
+        """
+        pass
+    
     def response(self, *inp) -> Any:
         """
-        Submit input from user then stall until next data is received and ready to display.
-        
-        :return: Outputs for gradio demo
-        :rtype: Iterable[Any] or Any
-        """
-        if self.showing_data:
-            try:
-                self.receive(*inp)
-            except Exception as e:
-                if type(e) is InvalidInputException:
-                    return self.handle_input_exception(*e.args)
-                else:
-                    raise e
-            
-            self.complete_task()
-        
-        # stall until new data ready
-        while not self.refresh():
-            time.sleep(0.5)
-        
-        return self.send() 
+        Submit input from user then stall until we have an output ready for them.
+        Assumes first two parameters in inp are ID and Task respectively
 
+        :param inp: Inputs from gradio components
+        
+        :return: New task, Outputs to give to gradio components
+        """
+
+        client_id : int = inp[0]
+        task : Task = None
+
+        try:
+            task = self.receive(*inp)
+        except Exception as e:
+            if type(e) is InvalidInputException:
+                return self.handle_input_exception(*e.args)
+
+        self.manager.submit_task(client_id, task)
+        task = self.manager.await_new_task(client_id)
+
+        return [task] + self.present(task)
+    
     def handle_input_exception(self, *args) -> Any:
         """
         Handle invalid input exceptions. Default behavior is to just present same data again.
@@ -189,26 +318,7 @@ class GradioClientFront:
         :return: Outputs for gradio demo
         :rtype: Iterable[Any] or Any
         """
-        return self.send()
-
-    @abstractmethod
-    def receive(self, *inp):
-        """
-        Take input from user and modify self.data in response appropriately.
-
-        :param input: All inputs to the gradio demo
-        """
-        pass
-
-    @abstractmethod
-    def send(self) -> Any:
-        """
-        Use self.data to send relevant data to user. 
-
-        :return: All outputs to gradio demo
-        :rtype: Iterable[any] or any
-        """
-        pass
+        return self.present()
 
 class InvalidInputException(Exception):
     """

--- a/backend/client/gradio_client.py
+++ b/backend/client/gradio_client.py
@@ -1,6 +1,6 @@
 from abc import abstractmethod
 
-from typing import Any, Iterable, Dict, Tuple, List
+from typing import Any, Iterable, Dict, Tuple, List, Callable
 
 from backend.data import BatchElement
 from backend.tasks import Task
@@ -274,6 +274,17 @@ class GradioFront:
         and outputs must go to/come out of the function.
         """
         pass
+
+    def wrap_event(self, event : Callable):
+        """
+        For any gradio event (i.e. gr.Button.click, gr.Slider.change),
+        wrap with this method to ensure id and task are passed properly.
+        """
+        return lambda fn, inputs, outputs : event(
+            fn, 
+            inputs = [self.id, self.task] + inputs if type(inputs) is list else [inputs],
+            outputs = [self.task] + outputs if type(outputs) is list else [outputs]
+            )
 
     @abstractmethod
     def receive(self, *inp) -> Task:

--- a/backend/data/__init__.py
+++ b/backend/data/__init__.py
@@ -3,4 +3,8 @@ from dataclasses import dataclass
 @dataclass
 class BatchElement:
     """Abstract base class for BatchElements. Store all kinds of data being passed around CHEESE"""
-    pass
+    client_id : int = -1 # ID of the client that was assigned the data last
+    trip : int = 0 # How many targets has the BatchElement visited so far?
+    trip_max : int = 1 # How many targets *should* the BatchElement visit before going back to pipeline
+    # Default value of 1 causes data to immediately go back to pipeline after labelling by user
+    # ex: Value of 3 would allow for data to follow pipeline -> client -> model -> client -> pipeline

--- a/backend/data/__init__.py
+++ b/backend/data/__init__.py
@@ -8,3 +8,4 @@ class BatchElement:
     trip_max : int = 1 # How many targets *should* the BatchElement visit before going back to pipeline
     # Default value of 1 causes data to immediately go back to pipeline after labelling by user
     # ex: Value of 3 would allow for data to follow pipeline -> client -> model -> client -> pipeline
+    error : bool = False # Used to mark bad data (i.e. when data is not properly presented to user)

--- a/backend/pipeline/datasets.py
+++ b/backend/pipeline/datasets.py
@@ -4,7 +4,6 @@ from typing import Iterable, Dict, Any
 from datasets import Dataset
 
 from backend.pipeline import Pipeline
-from backend.utils import make_empty_dataset
 
 class DatasetPipeline(Pipeline):
     """
@@ -18,7 +17,7 @@ class DatasetPipeline(Pipeline):
 
     def save_dataset(self):
         if self.res_dataset is None:
-            raise Exception("Error: Attempted to save result dataset without every initializing it.")
+            return
         if self.write_path is None:
             raise Exception("Error: Attempted to save result dataset without every specifiying a path to write to")
 

--- a/backend/pipeline/iterable_dataset.py
+++ b/backend/pipeline/iterable_dataset.py
@@ -9,7 +9,7 @@ import numpy as np
 
 from backend.pipeline.datasets import DatasetPipeline
 from backend.data import BatchElement
-from backend.utils import safe_mkdir, make_empty_dataset
+from backend.utils import safe_mkdir
 
 class IterablePipeline(DatasetPipeline):
     """
@@ -42,22 +42,9 @@ class IterablePipeline(DatasetPipeline):
             self.res_dataset = load_from_disk(write_path)
             self.progress = joblib.load("save_data/progress.joblib")
         except:
-            self.res_dataset = self.init_dataset()
-
             safe_mkdir("save_data")
             self.progress = 0
             self.save_dataset()
-    
-    @abstractmethod
-    def init_dataset(self) -> Dataset:
-        """
-        Create initial dataset to write batch elements to after they have been labelled/evaluated. Derived class
-        can easily implement with init_dataset_from_col_names(...)
-
-        :return: Empty dataset object
-        :rtype: datasets.Dataset
-        """
-        pass
 
     def exhausted(self) -> bool:
         return self.progress >= self.max_length or self.fail_next

--- a/backend/pipeline/text_captions.py
+++ b/backend/pipeline/text_captions.py
@@ -10,6 +10,7 @@ from backend.data.text_captions import TextCaptionBatchElement
 class TextCaptionPipeline(Pipeline):
     """
     Pipeline for captioning dataset of text
+    NOTE: This code is deprecated and must be updated to inherit from datasets
     """
 
     def __init__(self, read_path : str, write_path : str, force_new : bool = False):

--- a/backend/pipeline/wav_folder.py
+++ b/backend/pipeline/wav_folder.py
@@ -10,7 +10,7 @@ import numpy as np
 
 from backend.pipeline.datasets import DatasetPipeline
 from backend.data import BatchElement
-from backend.utils import safe_mkdir, make_empty_dataset
+from backend.utils import safe_mkdir
 
 def valid_audio_file(path):
     return path.endswith(".wav")

--- a/backend/pipeline/wav_folder.py
+++ b/backend/pipeline/wav_folder.py
@@ -101,7 +101,7 @@ class WavFolderPipeline(DatasetPipeline):
         Given a row to add to dataset, marks corresponding entry in index_book complete
         """
         path, _ = self.index_book[id]
-        self.res_dataset = self.res_dataset.add_item(row)
+        self.add_row_to_dataset(row)
 
         self.index_book[id][1] = True
         self.save_dataset()

--- a/examples/image_selection.py
+++ b/examples/image_selection.py
@@ -1,7 +1,7 @@
 from atexit import register
 from backend.pipeline.iterable_dataset import IterablePipeline, InvalidDataException
 from backend.data import BatchElement
-from backend.client.gradio_client import GradioClient, GradioClientFront
+from backend.client.gradio_client import GradioFront
 
 from backend.api import CHEESE
 
@@ -22,10 +22,14 @@ import time
 
 # BatchElement should store everything you want to write to result dataset
 # And everything you want to show the labeller
+# Ensure every field has a default value
+
+# Note that BatchElements have several parameters, so use keywords when calling
+# constructor on your own BatchElement
 @dataclass
 class ImageSelectionBatchElement(BatchElement):
-    img1_url : str
-    img2_url : str
+    img1_url : str = None
+    img2_url : str = None
     select : int = 0 # 0 None, -1 Left, 1, Right
     time : float = 0 # Time in seconds it took for user to select image
     bad_data : bool = False # For when images don't load and user can't respond
@@ -53,7 +57,8 @@ class ImageSelectionPipeline(IterablePipeline):
         url1 = self.fetch_next()
         url2 = self.fetch_next()
         
-        return ImageSelectionBatchElement(url1, url2)
+        res = ImageSelectionBatchElement(img1_url = url1, img2_url = url2)
+        return res
     
     def post(self, be : ImageSelectionBatchElement):
         """
@@ -77,95 +82,90 @@ def make_iter():
     return iter(ds)
 
 # The Front object is what will be responsible for showing data to the labeller and collecting their responses
-class ImageSelectionFront(GradioClientFront):
-    def __init__(self):
-        super().__init__()
+class ImageSelectionFront(GradioFront):
 
-        # All GradioClientFronts have three things you must use when constructing your own frontend for CHEESE
-        # 1. self.demo, which is the demo that is run through gradio
-        # 2. self.response, which is the method called to handle inputs/outputs going between Gradio and CHEESE
-        # 3. self.data, which is the BatchElement your pipeline uses
+    # main() is where you create your UI
+    def main(self):
 
-        with gr.Blocks() as self.demo:
-            with gr.Column():
-                gr.Textbox("Of the two images below, select whichever one you prefer over the other.",
-                    show_label = False, interactive = False
-                )
-                error_btn = gr.Button("Press This If An Image Is Not Loading")
-                error_btn.style(full_width = True)
-                with gr.Row():
-                    with gr.Column():
-                        im_left = gr.Image(show_label = False, shape = (256, 256))
-                        btn_left = gr.Button("Select Above")
-                        btn_left.style(full_width = True)
-                    with gr.Column():
-                        im_right = gr.Image(show_label = False, shape = (256, 256))
-                        btn_right = gr.Button("Select Above")
-                        btn_right.style(full_width = True)
+        # All GradioFronts have one main method you must use:
+        # self.response, which is the method called to handle inputs/outputs going between Gradio and CHEESE
+        # self.id and self.task are both gr.Variable attributes that should be passed as the first two
+        # parameters to any call to response. Additionally, self.task will be first value returned by
+        # response, with the rest being the output of present
 
-            # Note how both button clicks call response, but with different arguments
-            # The arguments to response will later be passed to self.receive(...)
-            # The result of response is whatever is outputted by self.send()
-            def btn_left_click():
-                return self.response("Left")
-            def btn_right_click():
-                return self.response("Right")
-            def error_click():
-                return self.response("Error")
-            
-            def register_click_event(object, event):
-                object.click(
-                    event, inputs = [], outputs = [im_left, im_right]
-                )
+        with gr.Column():
+            gr.Textbox("Of the two images below, select whichever one you prefer over the other.",
+                show_label = False, interactive = False
+            )
+            error_btn = gr.Button("Press This If An Image Is Not Loading")
+            error_btn.style(full_width = True)
+            with gr.Row():
+                with gr.Column():
+                    im_left = gr.Image(show_label = False, shape = (256, 256))
+                    btn_left = gr.Button("Select Above")
+                    btn_left.style(full_width = True)
+                with gr.Column():
+                    im_right = gr.Image(show_label = False, shape = (256, 256))
+                    btn_right = gr.Button("Select Above")
+                    btn_right.style(full_width = True)
 
-            register_click_event(btn_left, btn_left_click)
-            register_click_event(btn_right, btn_right_click)
-            register_click_event(error_btn, error_click)
+        # Note how both button clicks call response, but with different arguments
+        # The arguments to response will later be passed to self.receive(...)
+        # The result of response is whatever is outputted by self.send()
+        def btn_left_click(id, task):
+            return self.response(id, task, "Left")
 
-        self.response_timer = None
+        def btn_right_click(id, task):
+            return self.response(id, task, "Right")
 
-    # Response calls receive and passes along whatever input it got
-    # We update self.data (an ImageSelectionBatchElement) appropriately
-    def receive(self, *inp):
-        res = inp[0]
-        if res == "Left":
-            self.data.select = -1
-        elif res == "Right":
-            self.data.select = 1
-        else:
-            self.data.bad_data = True
+        def error_click(id, task):
+            return self.response(id, task, "Error")
         
-        # Log time it took them to make selection
-        if self.response_timer is not None:
-            self.data.time = time.time() - self.response_timer
-            self.response_timer = None
+        # Note how when we register an event in gradio,
+        # we ensure self.id and self.task are both the first two parameters of inputs
+        # AND the first two parameters of outputs
+        def register_click_event(object, event):
+            object.click(
+                event, inputs = [self.id, self.task], outputs = [self.task, im_left, im_right]
+            )
 
+        register_click_event(btn_left, btn_left_click)
+        register_click_event(btn_right, btn_right_click)
+        register_click_event(error_btn, error_click)
+
+    # Response calls receive and passes along id, task and whatever input it got
+    # We can use task.data to access the actual data that is being labelled
+    # and update it using the users response
+    def receive(self, *inp):
+        _, task, res = inp
+
+        if res == "Left":
+            task.data.select = -1
+        elif res == "Right":
+            task.data.select = 1
+        else:
+            task.data.bad_data = True
+        
+        return task
     
-    # This is what response eventually calls
-    # We return the data from the BatchElement that we want to show the labeller
-    def send(self):
-        # Start timer whenever a new piece of data is shown
-        self.response_timer = time.time()
-        return self.data.img1_url, self.data.img2_url
-
-# This class simply needs to be made to support connection between front end and the ClientManager in backend
-class ImageSelectionClient(GradioClient):
-    def init_front(self) -> str:
-        return super().init_front(ImageSelectionFront)
+    # Response finally calls present to create outputs for gradio to show user
+    # In this example, this is simply the next left and right image
+    def present(self, task):
+        data : ImageSelectionBatchElement = task.data
+        return data.img1_url, data.img2_url
 
 if __name__ == "__main__":
     # The pipeline kwargs are inherited from IterablePipeline
     cheese = CHEESE(
-        ImageSelectionPipeline, ImageSelectionClient,
+        ImageSelectionPipeline, ImageSelectionFront,
         pipeline_kwargs = {
             "iter" : make_iter(), "write_path" : "./img_dataset_res", "force_new" : True, "max_length" : 5
         }
     )
+    print(cheese.launch())
 
-    url1 = cheese.create_client(1)
-    url2 = cheese.create_client(2)
-    print(url1)
-    print(url2)
+    print(cheese.create_client(15))
+    print(cheese.create_client(71))
 
     while not cheese.finished:
         time.sleep(2)


### PR DESCRIPTION
Changes:

General:
- Gradio now has a separate ClientManager that can be enabled by setting a flag on the master CHEESE object

Gradio Scalability:
- Previously created many demos, one per client. This is extremely inefficient
- Now one demo that many users can connect to with different credentials
- All examples have been updated to follow new Gradio setup
- Creating UI is now even simpler

Authentication and user tracking:
- Users now have to login before they can begin labelling data
- Batch elements now intrinsically store the ID of the last client that labelled them
- Users can flag data as being erroneous

QOL
- Previously user would have to submit empty task to receive their first real task
- This has been fixed and task + data now present immediately after login
- Some old imports that are now redundant were causing errors on previous examples. These have been fixed.
- Examples are now even shorter and hopefully simpler