### PR TITLE
Add rule based feedback to architext example

### DIFF
--- a/examples/architext/architext_test.py
+++ b/examples/architext/architext_test.py
@@ -65,11 +65,10 @@ class ArchitextModel(BaseModel):
 
 class ArchitextFront(GradioFront):
     rules = [
-        "Spaces are allocated appropriately with respect to living conditions.",
-        "There is a pronounced space around which the design is structured.",
-        "Spaces in the design are functionally coherent.",
-        "The design is simple for its conditions.",
-        "The design contains no seperated (inaccessible) spaces.",
+        "The rooms are appropriately allocated for comfortable living.",
+        "The design is structured around a pronounced room.",
+        "The design is simple.",
+        "The design contains no inaccessible rooms.",
         "The design is plausible.",
         "The design makes sense."
     ]
@@ -82,7 +81,7 @@ class ArchitextFront(GradioFront):
                 feedback = gr.Textbox(label = "Feedback on Generation", interactive = False, value = " ")
                 rating = gr.Slider(label = "Generation Rating", minimum = 0, maximum = 10, step = 1, interactive = False,  value = 0)
                 rule = gr.Textbox(interactive = False, value = " ", visible = False)
-                rule_score = gr.Radio(choices = ["strongly disagree", "disagree", "neutral", "agree", "strongly agree"], interactive = False, value = " ")
+                rule_score = gr.Radio(choices = ["disagree", "mostly disagree", "unsure", "mostly agree", "agree"], interactive = False, value = " ")
                 spaces_to_remove = gr.CheckboxGroup(label = "Rooms to delete (ordered from top left to bottom right)", interactive = False, value = None, choices=[])
 
             with gr.Column():


### PR DESCRIPTION
**Details**
This PR adds two new input fields to the architext example. Rule is a randomly chosen design rule and rule score is a likert scale assessment of how well the  generated design adheres to the rule. This preference will be used to train a sparrow like rule model. This PR also sets the correct HuggingFace model path.

**Screenshots**
<img width="760" alt="Screenshot 2022-10-29 at 4 06 47 PM" src="https://user-images.githubusercontent.com/18430808/198855726-f810ff33-80a3-4505-85bd-15bbbb0284dd.png">
